### PR TITLE
Fix missing imports in resource files

### DIFF
--- a/src/__tests__/tools/calculator.test.ts
+++ b/src/__tests__/tools/calculator.test.ts
@@ -3,6 +3,9 @@
  * Tests for mathematical calculation functionality
  */
 
+import { calculateTool } from '../../tools/calculator.js';
+import { ToolContext } from '../../types/index.js';
+
 
 const mockContext: ToolContext = {
   requestId: 'test-request-123',

--- a/src/__tests__/utils/errors.test.ts
+++ b/src/__tests__/utils/errors.test.ts
@@ -11,7 +11,8 @@ import {
   createErrorResponse,
   generateRequestId,
   getErrorMessage,
-}
+} from '../../utils/errors.js';
+import { ToolContext } from '../../types/index.js';
 
 describe('Error Handling', () => {
   describe('Custom Error Classes', () => {

--- a/src/__tests__/utils/validation.test.ts
+++ b/src/__tests__/utils/validation.test.ts
@@ -4,6 +4,13 @@
  */
 
 import { z } from 'zod';
+import {
+  validateInput,
+  sanitizeString,
+  validateFilePath,
+  CommonSchemas,
+} from '../../utils/validation.js';
+import { ValidationErrorDetail } from '../../types/index.js';
 
 describe('Validation Utilities', () => {
   describe('validateInput', () => {

--- a/src/resources/config.ts
+++ b/src/resources/config.ts
@@ -3,6 +3,10 @@
  * Provides access to application configuration and settings
  */
 
+import { ResourceDefinition, ResourceContext } from '../types/index.js';
+import { getConfig } from '../utils/config.js';
+import { log } from '../utils/logger.js';
+
 
 /**
  * Configuration resource implementation

--- a/src/resources/docs.ts
+++ b/src/resources/docs.ts
@@ -3,6 +3,9 @@
  * Provides access to project documentation and help content
  */
 
+import { ResourceDefinition, ResourceContext } from '../types/index.js';
+import { log } from '../utils/logger.js';
+
 
 /**
  * Documentation resource implementation

--- a/src/resources/logs.ts
+++ b/src/resources/logs.ts
@@ -3,6 +3,9 @@
  * Provides access to application logs and recent events
  */
 
+import { ResourceDefinition, ResourceContext } from '../types/index.js';
+import { log } from '../utils/logger.js';
+
 
 /**
  * In-memory log storage for demonstration

--- a/src/tools/calculator.ts
+++ b/src/tools/calculator.ts
@@ -3,6 +3,9 @@
  * Provides basic mathematical operations and calculations
  */
 
+import { ToolDefinition, ToolContext } from '../types/index.js';
+import { log } from '../utils/logger.js';
+
 
 /**
  * Calculator tool implementation

--- a/src/tools/filesystem.ts
+++ b/src/tools/filesystem.ts
@@ -5,6 +5,9 @@
 
 import { promises as fs } from 'fs';
 import { join, resolve, relative } from 'path';
+import { ToolDefinition, ToolContext } from '../types/index.js';
+import { log } from '../utils/logger.js';
+import { validateFilePath } from '../utils/validation.js';
 
 /**
  * File system tool implementation

--- a/src/tools/text-processing.ts
+++ b/src/tools/text-processing.ts
@@ -3,6 +3,9 @@
  * Provides various text manipulation and analysis capabilities
  */
 
+import { ToolDefinition, ToolContext } from '../types/index.js';
+import { log } from '../utils/logger.js';
+
 
 /**
  * Text processing tool implementation

--- a/src/tools/weather.ts
+++ b/src/tools/weather.ts
@@ -3,6 +3,9 @@
  * Provides weather information and forecasts (mock implementation for template)
  */
 
+import { ToolDefinition, ToolContext } from '../types/index.js';
+import { log } from '../utils/logger.js';
+
 
 /**
  * Weather tool implementation

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,7 +5,7 @@
 
 import { config as loadEnv } from 'dotenv';
 import { Config, ConfigSchema } from '../types/index.js';
-import { log } from './logger';
+import { log } from './logger.js';
 
 // Load environment variables from .env file
 loadEnv();

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -3,6 +3,9 @@
  * Provides standardized error handling and custom error classes
  */
 
+import { ErrorResponse } from '../types/index.js';
+import { log } from './logger.js';
+
 
 /**
  * Base error class for MCP-related errors

--- a/src/utils/health.ts
+++ b/src/utils/health.ts
@@ -4,6 +4,8 @@
  */
 
 import { createServer, Server as HttpServer } from 'http';
+import { Config, HealthCheckResponse, ServerMetrics } from '../types/index.js';
+import { log } from './logger.js';
 
 /**
  * Health checker class

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -4,6 +4,7 @@
  */
 
 import { z } from 'zod';
+import { ValidationErrorDetail } from '../types/index.js';
 
 /**
  * Common validation schemas


### PR DESCRIPTION
Fixed all the missing import statements in the resource files, tool files, and test files. 

The main issues were:
Resource files (config.ts, docs.ts, logs.ts) were missing imports for:

ResourceDefinition and ResourceContext types
log utility from logger
getConfig utility (for config.ts)
Tool files were missing imports for:

ToolDefinition and ToolContext types
log utility from logger
Other specific utilities like validateFilePath
Utility files had some missing imports for types and cross-dependencies

Test files were missing imports for the modules they were testing

Import extensions - I also ensured all imports use the .js extension as required by ES modules in Node.js

These changes should resolve all the TypeScript compilation errors you're seeing in the GitHub Actions. The tests should now be able to find all the required types and utilities.